### PR TITLE
make fuzzyhelp faster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,7 @@ Imports:
     rstudioapi,
     rlang,
     shiny,
-    stringdist,
-    stringr,
+    stringi,
     utils
 Suggests:
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # felp 0.3.0
 
 - Added `fuzzyhelp` function which launches Shiny Gadget to search help topics fuzzily, and preview the result. Done button will also launch `help` function (#12, #13).
-- Added RStudio Addin named "Fuzzy Search on R Help", which launches the `fuzzyhelp` function (#12, #13).
+- Added RStudio Addin named "Fuzzy Search on R Help", which launches the `fuzzyhelp` function (#12, #13, #15).
 
 
 # felp 0.2.3

--- a/R/fuzzyhelp.R
+++ b/R/fuzzyhelp.R
@@ -177,7 +177,7 @@ create_ui <- function(query = "") {
 }
 
 parse_query <- function(string) {
-  queries <- stringr::str_split(string, "\\s+")[[1L]]
+  queries <- stringi::stri_split_fixed(string, " ")[[1L]]
   queries[queries != ""]
 }
 

--- a/R/fuzzyhelp.R
+++ b/R/fuzzyhelp.R
@@ -190,6 +190,7 @@ server <- function(input, output) {
     reactable::reactable(
       toc_matched,
       pagination = TRUE,
+      showPagination = TRUE,
       defaultPageSize = 20,
       selection = "single",
       defaultSelected = if (nrow(toc_matched) != 0) 1L,

--- a/R/fuzzyhelp.R
+++ b/R/fuzzyhelp.R
@@ -98,7 +98,9 @@ score_toc <- function(toc, queries) {
   prefilter <- rep(TRUE, N)
   unique_queries <- unique(queries)
   case_sensitive <- stringi::stri_detect_regex(unique_queries, "[:upper:]")
-  prefilter_queries <- stringi::stri_replace_all_regex(unique_queries, "(.)", "$1.*")
+  prefilter_queries <- unique_queries %>%
+    stringi::stri_replace_all_regex("(.)", "\\\\$1.*") %>%
+    stringi::stri_replace_all_regex("\\\\(\\w)", "$1")
   package <- toc$Package
   topic <- toc$Topic
   for (i in seq_along(unique_queries)) {

--- a/R/fuzzyhelp.R
+++ b/R/fuzzyhelp.R
@@ -33,11 +33,15 @@ get_vignette <- function(topic, package) {
 }
 
 
-get_content <- function(x) {
-  if (NROW(x) == 0L) return("")
-  type <- x$Type[1L]
-  topic <- x$Topic[1L]
-  package <- x$Package[1L]
+get_content <- function(x, i) {
+  if (NROW(x) == 0L || length(i) == 0L) return("")
+  if (length(i) > 1L) {
+    warning("i should be an integer vector of the length equal to 1.")
+    i <- i[[1L]]
+  }
+  type <- x$Type[i]
+  topic <- x$Topic[i]
+  package <- x$Package[i]
   if (type == "vignette") return(get_vignette(topic, package))
   get_help(topic, package)
 }
@@ -202,7 +206,7 @@ server <- function(input, output) {
   })
   reactiveHelp <- shiny::reactive(
     htmltools::tags$iframe(
-      srcdoc = get_content(reactiveToc()[reactiveSelection(), ]),
+      srcdoc = get_content(reactiveToc(), reactiveSelection()),
       style = "width: 100%; height: 100%;"
     )
   )

--- a/R/fuzzyhelp.R
+++ b/R/fuzzyhelp.R
@@ -95,10 +95,13 @@ score_toc <- function(toc, queries) {
   # the current implementation does not support space (` `) as a part of queries
   prefilter <- rep(TRUE, N)
   txt <- paste(toc$Package, toc$Topic)
+  opts <- stringi::stri_opts_regex(case_insensitive = TRUE)
   for (
     query in stringi::stri_replace_all_regex(unique(queries), "(.)", "$1.*")
   ) {
-    prefilter[prefilter] <- stringi::stri_detect_regex(txt[prefilter], query)
+    prefilter[prefilter] <- stringi::stri_detect_regex(
+      txt[prefilter], query, opts_regex = opts
+    )
     if (!any(prefilter)) {
       return(score)
     }
@@ -177,7 +180,7 @@ server <- function(input, output) {
       pagination = TRUE,
       defaultPageSize = 20,
       selection = "single",
-      defaultSelected = if(nrow(toc_matched) != 0) 1L,
+      defaultSelected = if (nrow(toc_matched) != 0) 1L,
       onClick = "select"
     )
   }))
@@ -203,12 +206,7 @@ server <- function(input, output) {
     package <- selection$Package[1L]
     if (rstudioapi::isAvailable()) {
       rstudioapi::sendToConsole(
-        sprintf(
-          '%s(%s, package = %s)',
-          type,
-          if (type == "help") topic else sprintf('"%s"', topic),
-          if (type == "help") package else sprintf('"%s"', package)
-        ),
+        sprintf('%s("%s", package = "%s")', type, topic, package),
         execute = TRUE
       )
     } else {

--- a/docs/articles/felp.html
+++ b/docs/articles/felp.html
@@ -366,11 +366,11 @@ Roxygen:           list(markdown = TRUE)
 RoxygenNote:       7.2.1
 Imports:           prettycode, curl, dplyr, htmltools, magrittr,
                    matrixStats, miniUI, reactable, rstudioapi, rlang,
-                   shiny, stringdist, stringr, utils
+                   shiny, stringi, utils
 Suggests:          knitr, printr, testthat (&gt;= 2.1.0), covr, rmarkdown
 VignetteBuilder:   knitr
 Language:          en-US
-Built:             R 4.2.1; ; 2022-08-22 23:29:53 UTC; unix
+Built:             R 4.2.1; ; 2022-09-21 13:47:15 UTC; unix
 
 Index:
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -53,7 +53,7 @@
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.3.0" id="felp-030">felp 0.3.0<a class="anchor" aria-label="anchor" href="#felp-030"></a></h2>
 <ul><li>Added <code>fuzzyhelp</code> function which launches Shiny Gadget to search help topics fuzzily, and preview the result. Done button will also launch <code>help</code> function (<a href="https://github.com/atusy/felp/issues/12" class="external-link">#12</a>, <a href="https://github.com/atusy/felp/issues/13" class="external-link">#13</a>).</li>
-<li>Added RStudio Addin named “Fuzzy Search on R Help”, which launches the <code>fuzzyhelp</code> function (<a href="https://github.com/atusy/felp/issues/12" class="external-link">#12</a>, <a href="https://github.com/atusy/felp/issues/13" class="external-link">#13</a>).</li>
+<li>Added RStudio Addin named “Fuzzy Search on R Help”, which launches the <code>fuzzyhelp</code> function (<a href="https://github.com/atusy/felp/issues/12" class="external-link">#12</a>, <a href="https://github.com/atusy/felp/issues/13" class="external-link">#13</a>, <a href="https://github.com/atusy/felp/issues/15" class="external-link">#15</a>).</li>
 </ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.2.3" id="felp-023">felp 0.2.3<small>2020-09-14</small><a class="anchor" aria-label="anchor" href="#felp-023"></a></h2>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 2.0.6
 pkgdown_sha: ~
 articles:
   felp: felp.html
-last_built: 2022-08-22T23:29Z
+last_built: 2022-09-21T13:47Z
 


### PR DESCRIPTION
- improve speed by regex-based prefilters
- pre-filter should be case-insensitive
- package and topic should evaluate queries independently
- fix errors from showing help without selection
- move to base::adist-based algo
- improve handling of regex-special chars
