### PR TITLE
On fuzzyhelp's UI, anchors to ID should scroll the window to the element with the corresponding ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# felp 0.3.0.9999
+
+- Fixed wrong behaviors of anchors in the HTML help in the UI of the `fuzzyhelp` function.
+  A click on a anchor should not cause nesting of the UI when href of the anchor is an ID.
+  Instead, the click should scroll the window to show the element with the corresponding ID.
+
 # felp 0.3.0
 
 - Added `fuzzyhelp` function which launches Shiny Gadget to search help topics fuzzily, and preview the result. Done button will also launch `help` function. 

--- a/R/fuzzyhelp.R
+++ b/R/fuzzyhelp.R
@@ -308,7 +308,23 @@ create_server <- function(method = c("fzf", "lv")) {
     reactiveHelp <- shiny::reactive(
       htmltools::tags$iframe(
         srcdoc = get_content(reactiveToc(), reactiveSelection()),
-        style = "width: 100%; height: 100%;"
+        style = "width: 100%; height: 100%;",
+        id = "helpViewer",
+        onload = "(function(){
+          // replace anchors to avoid nesting shiny widgets
+          const pattern = document.baseURI + '#';
+          const iframe = document.querySelector('#helpViewer iframe');
+          Array.from(iframe.contentDocument.querySelectorAll('a'))
+            .filter(a => a.href.startsWith(pattern))
+            .map(a => {
+              const id = a.href.slice(pattern.length);
+              a.href = 'javascript:void(0)';
+              a.onclick = function() {
+                const top = iframe.contentDocument.getElementById(id).offsetTop;
+                iframe.contentWindow.scrollTo({ top: top, behavior: 'smooth' });
+              }
+            });
+        })();"
       )
     )
 

--- a/docs/404.html
+++ b/docs/404.html
@@ -98,7 +98,7 @@ Content not found. Please use links in the navbar.
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer>

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -68,7 +68,7 @@ COPYRIGHT HOLDER: YASUMOTO Atsushi
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/LICENSE.html
+++ b/docs/LICENSE.html
@@ -72,7 +72,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -65,7 +65,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -64,14 +64,14 @@
     </div>
 
 
-    <p>Yasumoto A (2022).
+    <p>Yasumoto A (2024).
 <em>felp: Functional Help for Functions, Objects, and Packages</em>.
 R package version 0.3.0, <a href="https://github.com/atusy/felp" class="external-link">https://github.com/atusy/felp</a>. 
 </p>
     <pre>@Manual{,
   title = {felp: Functional Help for Functions, Objects, and Packages},
   author = {Atsushi Yasumoto},
-  year = {2022},
+  year = {2024},
   note = {R package version 0.3.0},
   url = {https://github.com/atusy/felp},
 }</pre>
@@ -87,7 +87,7 @@ R package version 0.3.0, <a href="https://github.com/atusy/felp" class="external
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -184,7 +184,7 @@
 
 <div class="pkgdown">
   <p></p>
-<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+<p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -1,7 +1,7 @@
-pandoc: '2.18'
-pkgdown: 2.0.6
+pandoc: 3.1.11.1
+pkgdown: 2.0.7
 pkgdown_sha: ~
 articles:
   felp: felp.html
-last_built: 2022-10-09T12:48Z
+last_built: 2024-03-27T15:05Z
 

--- a/docs/reference/dummy.html
+++ b/docs/reference/dummy.html
@@ -76,7 +76,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/felp.html
+++ b/docs/reference/felp.html
@@ -140,7 +140,7 @@ For a function, its source is returned instead of <code><a href="https://rdrr.io
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/fuzzyhelp.html
+++ b/docs/reference/fuzzyhelp.html
@@ -107,7 +107,7 @@ previous characters.</p>
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -82,7 +82,7 @@
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>

--- a/docs/reference/question.html
+++ b/docs/reference/question.html
@@ -123,7 +123,7 @@ Otherwise, <code>e2</code> is same as <code>type</code> argument of <code><a hre
 </div>
 
 <div class="pkgdown">
-  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.6.</p>
+  <p></p><p>Site built with <a href="https://pkgdown.r-lib.org/" class="external-link">pkgdown</a> 2.0.7.</p>
 </div>
 
       </footer></div>


### PR DESCRIPTION
- **fix(fuzzyhelp): anchors to id should scroll**
- **chore(news): anchors to id should scroll**
- **chore(docs): pkgdown::build_site()**
