### PR TITLE
felp::を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ source("https://install-github.me/atusy/felp")
 
 ### Fuzzy search and preview of help
 
-with `fuzzyhelp()` or "Fuzzy Search on R Help" RStudio Addin
+with `felp::fuzzyhelp()` or "Fuzzy Search on R Help" RStudio Addin
 
 ![Fuzzy search and preview of help](https://felp.atusy.net/reference/figures/fuzzyhelp.gif)
 


### PR DESCRIPTION
Tokyo.Rのメッセージ[https://r-wakalang.slack.com/archives/C06PCLP8R/p1715320778689009](https://r-wakalang.slack.com/archives/C06PCLP8R/p1715320778689009)を拝見しました。初心者にやさしいパッケージを作成いただきありがとうございます。初心者はパッケージ読み込みの仕方もわからないことがあるので、`felp::`を追記したほうがわかりやすいかと思いました。ご検討よろしくお願い致します。